### PR TITLE
Update mod for 1.6

### DIFF
--- a/Source/ExtraHediffStats.cs
+++ b/Source/ExtraHediffStats.cs
@@ -96,21 +96,35 @@ namespace XenobionicPatcher {
                 displayPriorityWithinCategory: 4940
             );
 
-            if (hediff.causesNeed != null) yield return new StatDrawEntry(
+            // Note: In v1.6, `<causesNeed>` has been removed. `<chemicalNeed>` on the `HediffDef` root is used for drugs
+            if (hediff.chemicalNeed != null) yield return new StatDrawEntry(
                 category:    category,
                 label:       "CreatesNeed".Translate(),
                 reportText:  "Stat_Hediff_CausesNeed_Desc".Translate(),
-                valueString: hediff.causesNeed.LabelCap,
-                hyperlinks:  new[] { new Dialog_InfoCard.Hyperlink(hediff.causesNeed) },
+                valueString: hediff.chemicalNeed.LabelCap,
+                hyperlinks:  new[] { new Dialog_InfoCard.Hyperlink(hediff.chemicalNeed) },
                 displayPriorityWithinCategory: 4935
             );
 
-            if (!hediff.disablesNeeds.NullOrEmpty()) yield return new StatDrawEntry(
+            // Note: In v1.6, `<causesNeed>` has been removed. Non-drug needs are now listed as `<enablesNeeds>` in the `HediffStage`
+            if (!hediff.stages.Any(s => s.enablesNeeds.Any())) yield return new StatDrawEntry(
+                category: category,
+                label: "Stat_Hediff_EnablesNeeds_Name".Translate(),
+                reportText: "Stat_Hediff_EnablesNeeds_Desc".Translate(),
+                // Now need to grab the list of needs from any `<HediffStage>` that has them
+                valueString: GenText.ToCommaList(hediff.stages.Where(s => s.enablesNeeds.Any()).SelectMany(nd => nd.enablesNeeds.Select(dn => dn.LabelCap.ToString()))),
+                hyperlinks: hediff.stages.Where(s => s.enablesNeeds.Any()).SelectMany(nd => nd.enablesNeeds.Select(dn => new Dialog_InfoCard.Hyperlink(dn)).ToArray()),
+                displayPriorityWithinCategory: 4930
+            );
+            
+            // Note: In v1.6, `<disablesNeeds>` has been moved to `HediffStage` 
+            if (!hediff.stages.Any(s => s.disablesNeeds.Any())) yield return new StatDrawEntry(
                 category:    category,
                 label:       "Stat_Hediff_DisablesNeeds_Name".Translate(),
                 reportText:  "Stat_Hediff_DisablesNeeds_Desc".Translate(),
-                valueString: GenText.ToCommaList( hediff.disablesNeeds.Select(nd => nd.LabelCap.ToString()) ),
-                hyperlinks:  hediff.disablesNeeds.Select(nd => new Dialog_InfoCard.Hyperlink(nd)).ToArray(),
+                // Now need to grab the list of needs from any `<HediffStage>` that has them
+                valueString: GenText.ToCommaList( hediff.stages.Where(s => s.disablesNeeds.Any()).SelectMany(nd => nd.disablesNeeds.Select(dn => dn.LabelCap.ToString()) )),
+                hyperlinks:  hediff.stages.Where(s => s.disablesNeeds.Any()).SelectMany(nd => nd.disablesNeeds.Select(dn => new Dialog_InfoCard.Hyperlink(dn)).ToArray()),
                 displayPriorityWithinCategory: 4930
             );
 

--- a/Source/ExtraHediffStats.cs
+++ b/Source/ExtraHediffStats.cs
@@ -107,7 +107,7 @@ namespace XenobionicPatcher {
             );
 
             // Note: In v1.6, `<causesNeed>` has been removed. Non-drug needs are now listed as `<enablesNeeds>` in the `HediffStage`
-            if (!hediff.stages.Any(s => s.enablesNeeds.Any())) yield return new StatDrawEntry(
+            if (hediff.stages.Any(s => s.enablesNeeds.Any())) yield return new StatDrawEntry(
                 category: category,
                 label: "Stat_Hediff_EnablesNeeds_Name".Translate(),
                 reportText: "Stat_Hediff_EnablesNeeds_Desc".Translate(),
@@ -118,7 +118,7 @@ namespace XenobionicPatcher {
             );
             
             // Note: In v1.6, `<disablesNeeds>` has been moved to `HediffStage` 
-            if (!hediff.stages.Any(s => s.disablesNeeds.Any())) yield return new StatDrawEntry(
+            if (hediff.stages.Any(s => s.disablesNeeds.Any())) yield return new StatDrawEntry(
                 category:    category,
                 label:       "Stat_Hediff_DisablesNeeds_Name".Translate(),
                 reportText:  "Stat_Hediff_DisablesNeeds_Desc".Translate(),

--- a/Source/ExtraHediffStats.cs
+++ b/Source/ExtraHediffStats.cs
@@ -107,24 +107,24 @@ namespace XenobionicPatcher {
             );
 
             // Note: In v1.6, `<causesNeed>` has been removed. Non-drug needs are now listed as `<enablesNeeds>` in the `HediffStage`
-            if (hediff.stages.Any(s => s.enablesNeeds.Any())) yield return new StatDrawEntry(
+            if (hediff.stages?.FirstOrDefault(s => s.enablesNeeds != null) != null) yield return new StatDrawEntry(
                 category: category,
-                label: "Stat_Hediff_EnablesNeeds_Name".Translate(),
-                reportText: "Stat_Hediff_EnablesNeeds_Desc".Translate(),
+                label: "CreatesNeed".Translate(),
+                reportText: "Stat_Hediff_CausesNeed_Desc".Translate(),
                 // Now need to grab the list of needs from any `<HediffStage>` that has them
-                valueString: GenText.ToCommaList(hediff.stages.Where(s => s.enablesNeeds.Any()).SelectMany(nd => nd.enablesNeeds.Select(dn => dn.LabelCap.ToString()))),
-                hyperlinks: hediff.stages.Where(s => s.enablesNeeds.Any()).SelectMany(nd => nd.enablesNeeds.Select(dn => new Dialog_InfoCard.Hyperlink(dn)).ToArray()),
+                valueString: GenText.ToCommaList(hediff.stages.Where(s => s.enablesNeeds != null).SelectMany(nd => nd.enablesNeeds.Select(dn => dn.LabelCap.ToString())).Distinct()),
+                hyperlinks: hediff.stages.Where(s => s.enablesNeeds != null).SelectMany(nd => nd.enablesNeeds.Select(dn => new Dialog_InfoCard.Hyperlink(dn)).ToArray()),
                 displayPriorityWithinCategory: 4930
             );
             
             // Note: In v1.6, `<disablesNeeds>` has been moved to `HediffStage` 
-            if (hediff.stages.Any(s => s.disablesNeeds.Any())) yield return new StatDrawEntry(
+            if (hediff.stages?.FirstOrDefault(s => s.disablesNeeds != null) != null) yield return new StatDrawEntry(
                 category:    category,
                 label:       "Stat_Hediff_DisablesNeeds_Name".Translate(),
                 reportText:  "Stat_Hediff_DisablesNeeds_Desc".Translate(),
                 // Now need to grab the list of needs from any `<HediffStage>` that has them
-                valueString: GenText.ToCommaList( hediff.stages.Where(s => s.disablesNeeds.Any()).SelectMany(nd => nd.disablesNeeds.Select(dn => dn.LabelCap.ToString()) )),
-                hyperlinks:  hediff.stages.Where(s => s.disablesNeeds.Any()).SelectMany(nd => nd.disablesNeeds.Select(dn => new Dialog_InfoCard.Hyperlink(dn)).ToArray()),
+                valueString: GenText.ToCommaList( hediff.stages.Where(s => s.disablesNeeds != null).SelectMany(nd => nd.disablesNeeds.Select(dn => dn.LabelCap.ToString()) ).Distinct()),
+                hyperlinks:  hediff.stages.Where(s => s.disablesNeeds != null).SelectMany(nd => nd.disablesNeeds.Select(dn => new Dialog_InfoCard.Hyperlink(dn)).ToArray()),
                 displayPriorityWithinCategory: 4930
             );
 

--- a/Source/XenobionicPatcher.csproj
+++ b/Source/XenobionicPatcher.csproj
@@ -14,7 +14,7 @@
     <Configuration>Debug</Configuration>
     <Platform>AnyCPU</Platform>
 
-    <OutputPath>..\1.5\Assemblies\</OutputPath>
+    <OutputPath>..\1.6\Assemblies\</OutputPath>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>


### PR DESCRIPTION
I took the liberty of looking at the source code to see how much work would be needed to bring it up to v1.6 and, from my initial testing, it appears not too much.

In `ExtraHediffStats.cs`:

* `causesNeed` has been removed. Code has been updated and split into to parts to reflect these changes: 
  * `chemicalNeed` on `HediffDef` is now used for drugs. 
  * Non-drug needs now use `enablesNeeds` in `HediffStage`. 
* `disablesNeeds` has also been moved to `HediffStage`

I admit I haven't done *extensive* testing, yet, but the game *does* load without any red errors and I *am* able to install an Archotech eye on a dog, so it appears promising.

&nbsp;

While I have worked extensively with C# and XML for the last decade, RimWorld modding is still relatively new to me so I fully expect there to be some other factors I may have overlooked. 